### PR TITLE
Initial pass at classed errors

### DIFF
--- a/R/data-utils.R
+++ b/R/data-utils.R
@@ -18,7 +18,7 @@ HTEFold <- R6::R6Class("HTEFold", list(
     #' @return Returns an object of class `HTEFold`
     initialize = function(data, split_id) {
         if (!(".split_id" %in% names(data))) {
-            stop("Must construct split identifiers before splitting.")
+            abort_data("Must construct split identifiers before splitting.")
         }
         num_splits <- length(unique(data$.split_id))
         # check that the split_id is valid
@@ -132,7 +132,7 @@ check_splits <- function(data) {
     if (!("num_splits" %in% attrs)) ok <- FALSE
     if (!("identifier" %in% attrs)) ok <- FALSE
 
-    if (!ok) stop("You must first construct splits with `tidyhte::make_splits`.")
+    if (!ok) abort_data("You must first construct splits with `tidyhte::make_splits`.")
 }
 
 #' Checks that nuisance models have been estimated and exist in the supplied dataset.
@@ -150,7 +150,7 @@ check_nuisance_models <- function(data) {
     if (!(".mu0_hat" %in% cols)) ok <- FALSE
     if (!(".mu1_hat" %in% cols)) ok <- FALSE
 
-    if (!ok) stop("You must first estimate plugin models with `tidyhte::produce_plugin_estimates`.")
+    if (!ok) abort_data("You must first estimate plugin models with `tidyhte::produce_plugin_estimates`.")
 }
 
 #' Removes rows which have missing data on any of the supplied columns.
@@ -212,7 +212,7 @@ check_identifier <- function(data, id_col) {
 
     if (!ok) {
         msg <- "Invalid identifier. Each unit / cluster must have its own unique ID."
-        stop(msg)
+        abort_data(msg)
     }
 }
 
@@ -227,7 +227,7 @@ check_identifier <- function(data, id_col) {
 check_weights <- function(data, weight_col) {
     if (!(weight_col %in% names(data))) {
         msg <- "Invalid weight column. Must exist in dataframe."
-        stop(msg)
+        abort_data(msg)
     }
 
     wts <- data[[weight_col]]
@@ -236,12 +236,12 @@ check_weights <- function(data, weight_col) {
 
     if (!is_num) {
         msg <- "Invalid weight column. Must be numeric."
-        stop(msg)
+        abort_data(msg)
     }
 
     if (min(wts) < 0) {
         msg <- "Invalid weight column. Must be non-negative."
-        stop(msg)
+        abort_data(msg)
     }
 }
 
@@ -256,6 +256,6 @@ check_weights <- function(data, weight_col) {
 check_data_has_hte_cfg <- function(data) {
     if (! "HTE_cfg" %in% names(attributes(data))) {
         msg <- "Must attach HTE_cfg with `attach_config`."
-        stop(msg)
+        abort_config(msg)
     }
 }

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -5,7 +5,7 @@ SL_model_slot <- function(prediction) {
     else if (prediction == ".mu1_hat") "mu1"
     else if (prediction == ".mu0_hat") "mu0"
     else if (prediction == ".pseudo_outcome_hat") "fx"
-    else stop("Unknown model slot.")
+    else abort_model("Unknown model slot.")
 }
 
 #' Function to calculate diagnostics based on model outputs

--- a/R/errors.R
+++ b/R/errors.R
@@ -1,0 +1,92 @@
+#' Error utilities for tidyhte package
+#'
+#' These functions provide a standardized way to throw classed errors throughout
+#' the tidyhte package, replacing basic `stop()` calls with structured error
+#' conditions that can be caught and handled programmatically.
+#'
+#' @details
+#' The tidyhte package uses a hierarchical error class system based on rlang's
+#' structured condition handling. All tidyhte errors inherit from the base class
+#' `tidyhte_error_general` and include more specific subclasses:
+#'
+#' * `tidyhte_error_config` - Configuration-related errors
+#' * `tidyhte_error_model` - Model-related errors  
+#' * `tidyhte_error_data` - Data validation errors
+#' * `tidyhte_error_not_implemented` - Not implemented functionality
+#' * `tidyhte_error_package` - Package dependency errors
+#'
+#' These classed errors can be caught using `tryCatch()` or `rlang::catch_cnd()`
+#' with the specific error class for more precise error handling.
+#'
+#' @examples
+#' \dontrun{
+#' # Catching specific error types
+#' tryCatch(
+#'   some_tidyhte_function(),
+#'   tidyhte_error_config = function(e) cat("Configuration error:", conditionMessage(e)),
+#'   tidyhte_error_data = function(e) cat("Data error:", conditionMessage(e))
+#' )
+#' }
+#'
+#' @name tidyhte-errors
+#' @keywords internal
+NULL
+
+#' Throw a tidyhte error
+#'
+#' @param message Error message
+#' @param class Error class suffix (will be prefixed with "tidyhte_error_")
+#' @param ... Additional arguments passed to `rlang::abort()`
+#' @keywords internal
+tidyhte_abort <- function(message, class = "general", ...) {
+    rlang::abort(
+        message = message,
+        class = paste0("tidyhte_error_", class),
+        ...
+    )
+}
+
+#' Configuration-related errors
+#'
+#' @param message Error message
+#' @param ... Additional arguments passed to `tidyhte_abort()`
+#' @keywords internal
+abort_config <- function(message, ...) {
+    tidyhte_abort(message, class = "config", ...)
+}
+
+#' Model-related errors
+#'
+#' @param message Error message
+#' @param ... Additional arguments passed to `tidyhte_abort()`
+#' @keywords internal
+abort_model <- function(message, ...) {
+    tidyhte_abort(message, class = "model", ...)
+}
+
+#' Data validation errors
+#'
+#' @param message Error message
+#' @param ... Additional arguments passed to `tidyhte_abort()`
+#' @keywords internal
+abort_data <- function(message, ...) {
+    tidyhte_abort(message, class = "data", ...)
+}
+
+#' Not implemented errors
+#'
+#' @param message Error message
+#' @param ... Additional arguments passed to `tidyhte_abort()`
+#' @keywords internal
+abort_not_implemented <- function(message = "Not implemented", ...) {
+    tidyhte_abort(message, class = "not_implemented", ...)
+}
+
+#' Package dependency errors
+#'
+#' @param message Error message
+#' @param ... Additional arguments passed to `tidyhte_abort()`
+#' @keywords internal
+abort_package <- function(message, ...) {
+    tidyhte_abort(message, class = "package", ...)
+}

--- a/R/meta_cfg.R
+++ b/R/meta_cfg.R
@@ -118,7 +118,7 @@ PCATE_cfg <- R6::R6Class("PCATE_cfg",
             } else if (is.list(num_mc_samples)) {
                 self$num_mc_samples <- num_mc_samples
             } else {
-                stop("Unknown type of num_mc_samples")
+                abort_config("Unknown type of num_mc_samples")
             }
             invisible(self)
         },
@@ -346,7 +346,7 @@ QoI_cfg <- R6::R6Class("QoI_cfg",
             mcate = NULL, pcate = NULL, vimp = NULL, diag = NULL, ate = TRUE, predictions = FALSE
         ) {
             if (is.null(mcate) && is.null(pcate) && is.null(vimp) && is.null(diag)) {
-                stop("Must define at least one QoI!")
+                abort_config("Must define at least one QoI!")
             }
             if (!is.null(mcate)) self$mcate <- mcate
             if (!is.null(pcate)) self$pcate <- pcate

--- a/R/predictor.R
+++ b/R/predictor.R
@@ -2,7 +2,7 @@
 #' @keywords internal
 predictor_factory <- function(cfg, ...) {
     if (!("model_class" %in% names(cfg))) {
-        stop("Unknown model class.")
+        abort_model("Model configuration must include 'model_class' field.")
     } else if (cfg$model_class == "known") {
         KnownPredictor$new(cfg$covariate_name)
     } else if (cfg$model_class == "SL") {
@@ -14,7 +14,7 @@ predictor_factory <- function(cfg, ...) {
     } else if (cfg$model_class == "Constant") {
         ConstantPredictor$new()
     } else {
-        stop("Unknown model class.")
+        abort_model(paste0("Unknown model class: '", cfg$model_class, "'."))
     }
 }
 
@@ -27,13 +27,13 @@ Predictor <- R6::R6Class("Predictor",
             warning("Not Implemented")
         },
         fit = function(labels, features) {
-            stop("Not Implemented")
+            abort_not_implemented("fit() method not implemented for base Predictor class")
         },
         predict = function(features) {
-            stop("Not Implemented")
+            abort_not_implemented("predict() method not implemented for base Predictor class")
         },
         predict_se = function(features) {
-            stop("Not Implemented")
+            abort_not_implemented("predict_se() method not implemented for base Predictor class")
         }
     )
 )
@@ -148,7 +148,7 @@ KernelSmoothPredictor <- R6::R6Class("KernelSmoothPredictor",
         fit = function(data) {
             self$label <- data$label
             self$covariates <- drop(data$features)
-            if (any(data$weights != 1)) stop("`nprobust` does not support the use of weights.")
+            if (any(data$weights != 1)) abort_package("`nprobust` does not support the use of weights.")
             eval_pts <- quantile(
                 self$covariates,
                 probs = seq(self$eval_min_quantile, 1 - self$eval_min_quantile, length = self$neval)

--- a/R/qoi.R
+++ b/R/qoi.R
@@ -44,7 +44,7 @@ pseudo_outcome_factory <- function(type) {
     } else if (type == "plugin") {
         plugin_pseudo_outcome
     } else {
-        stop("Unknown type of pseudo-outcome.")
+        abort_config("Unknown type of pseudo-outcome.")
     }
 }
 

--- a/R/recipe-api.R
+++ b/R/recipe-api.R
@@ -235,7 +235,7 @@ add_moderator <- function(hte_cfg, model_type, ..., .model_arguments = NULL) {
     } else if (tolower(model_type) == "kernelsmooth") {
         model_cls <- KernelSmooth_cfg
     } else {
-        stop("Unknown `model_type`.")
+        abort_config("Unknown `model_type`.")
     }
 
     qoi_list <- rlang::list2()

--- a/R/variable_importance.R
+++ b/R/variable_importance.R
@@ -31,9 +31,9 @@ calculate_vimp <- function(full_data, weight_col, pseudo_outcome, ..., .VIMP_cfg
     unq_splits <- unique(split_ids)
     num_splits_in_data <- length(unq_splits)
     num_splits_in_attr <- attr(full_data, "num_splits")
-    if (num_splits_in_data != num_splits_in_attr) stop("Number of splits is inconsistent.")
+    if (num_splits_in_data != num_splits_in_attr) abort_data("Number of splits is inconsistent.")
     if (ceiling(num_splits_in_data / 2) != floor(num_splits_in_data / 2)) {
-        stop("Number of splits must be even to calculate VIMP.")
+        abort_data("Number of splits must be even to calculate VIMP.")
     }
 
     sample_splitting <- .VIMP_cfg$sample_splitting

--- a/tests/testthat/test-predictor.R
+++ b/tests/testthat/test-predictor.R
@@ -7,25 +7,25 @@ test_that("predictor factory", {
     checkmate::expect_r6(predictor_factory(model_cfg), classes = "Predictor")
 
     model_cfg <- Model_cfg$new()
-    expect_error(predictor_factory(model_cfg), "Unknown model class.")
+    expect_error(predictor_factory(model_cfg), class = "tidyhte_error_model")
 
-    expect_error(predictor_factory(list(model_class = "test")), "Unknown model class.")
+    expect_error(predictor_factory(list(model_class = "test")), class = "tidyhte_error_model")
 
-    expect_error(predictor_factory("test"), "Unknown model class.")
+    expect_error(predictor_factory("test"), class = "tidyhte_error_model")
 })
 
 test_that("base Predictor class", {
     expect_warning(pred <- Predictor$new(), "Not Implemented")
-    expect_error(pred$fit(y, x))
-    expect_error(pred$predict(data))
-    expect_error(pred$predict_se(data))
+    expect_error(pred$fit(y, x), class = "tidyhte_error_not_implemented")
+    expect_error(pred$predict(data), class = "tidyhte_error_not_implemented")
+    expect_error(pred$predict_se(data), class = "tidyhte_error_not_implemented")
 })
 
 test_that("check check_nuisance_models", {
     df <- dplyr::tibble(a = 1:10, b = letters[1:10])
     expect_error(
         check_nuisance_models(df),
-        "You must first estimate plugin models with `tidyhte::produce_plugin_estimates`."
+        class = "tidyhte_error_data"
     )
 })
 


### PR DESCRIPTION
This addresses Issue #1 by providing classed errors using `rlang` style. The errors are hierarchical so that they demonstrate (1) that they come from tidyhte and (2) what the problem raised is.